### PR TITLE
fix: add nui.nvim dependency check and update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,15 +20,43 @@ pile.nvim is a Neovim plugin that provides a vertical buffer sidebar, similar to
 - Automatically updates file names when a buffer is renamed.(not implemented yet)
 - LSP integration: Automatically updates import paths when a file is renamed.(not implemented yet)
 
+## Requirements
+
+- Neovim 0.5 or later
+- [nui.nvim](https://github.com/MunifTanjim/nui.nvim) - Required for UI components
+- LSP configuration for full renaming functionality (optional)
 
 ## Installation
 
-Using Lazy.nvim:
+### Using [Lazy.nvim](https://github.com/folke/lazy.nvim)
+
 ```lua
 {
   'shabaraba/pile.nvim',
-  opts ={}
+  dependencies = {
+    'MunifTanjim/nui.nvim', -- Required dependency
+  },
+  opts = {}
 }
+```
+
+### Using [Packer.nvim](https://github.com/wbthomason/packer.nvim)
+
+```lua
+use {
+  'shabaraba/pile.nvim',
+  requires = { 'MunifTanjim/nui.nvim' }, -- Required dependency
+  config = function()
+    require('pile').setup()
+  end
+}
+```
+
+### Using [vim-plug](https://github.com/junegunn/vim-plug)
+
+```vim
+Plug 'MunifTanjim/nui.nvim'  " Required dependency
+Plug 'shabaraba/pile.nvim'
 ```
 
 ## Setup and Configuration
@@ -55,29 +83,20 @@ require('pile').setup({
 
 1. Open Buffers: The sidebar shows all open buffers, with the current buffer highlighted.
 
-
-
 ## Usage
 
 Open the sidebar:
-:PileOpen
+:PileToggle
 or set a keybind in your init.lua:
 
-vim.api.nvim_set_keymap('n', '<leader>ps', ':PileOpen<CR>', { noremap = true, silent = true })
+vim.api.nvim_set_keymap('n', '<leader>ps', ':PileToggle<CR>', { noremap = true, silent = true })
 
-Close the sidebar:
-:PileClose
+Navigate between buffers:
+:PileGoToNextBuffer
+:PileGoToPrevBuffer
 
 Rename a buffer:
 Edit the buffer name directly in the sidebar and save the changes to rename the file.
-
-
-## Requirements
-
-Neovim 0.5 or later
-
-LSP configuration for full renaming functionality
-
 
 ## Contributing
 

--- a/lua/pile/init.lua
+++ b/lua/pile/init.lua
@@ -1,11 +1,33 @@
 Config = require("pile.config")
 local buffers = require("pile.buffers")
 local sidebar = require("pile.windows.sidebar")
+local log = require("pile.log")
 
 local M = {}
 
+-- nui.nvimの依存関係をチェック
+local function check_dependencies()
+  log.trace("Checking dependencies...")
+  local has_nui, nui = pcall(require, "nui.popup")
+  if not has_nui then
+    log.error("Required dependency nui.nvim not found. Please install it with your plugin manager.")
+    vim.notify(
+      "pile.nvim requires nui.nvim to be installed. Please add it to your plugin manager.",
+      vim.log.levels.ERROR
+    )
+    return false
+  end
+  log.trace("All dependencies found")
+  return true
+end
+
 ---@param opts Config
 function M.setup(opts)
+  -- 依存関係のチェック
+  if not check_dependencies() then
+    return
+  end
+  
   Config.setup(opts)
 
   -- ハイライトグループを定義


### PR DESCRIPTION
## 概要

Issue #25 で報告されている「Error on load: module 'nui.popup' not found」エラーを解決するために、`nui.nvim`の依存関係チェックを追加し、ドキュメント（README）を更新しました。

## 修正内容

### 1. 依存関係チェック機能の追加（`init.lua`）

- `nui.nvim`の存在を確認する機能を実装
- 依存関係が欠けている場合に明確なエラーメッセージを表示
- ログシステムを使用して詳細な診断情報を提供
- プラグイン初期化前に依存関係をチェックし、問題があれば初期化を中止

### 2. ドキュメントの改善（`README.md`）

- 「Requirements」セクションに`nui.nvim`を必須依存関係として明記
- 主要なプラグインマネージャー（Lazy.nvim、Packer.nvim、vim-plug）での正しいインストール方法を追加
- 誤っていたコマンド名を修正（PileOpen → PileToggle）
- ナビゲーションコマンド（PileGoToNextBuffer、PileGoToPrevBuffer）の説明を追加

## テスト方法

以下の環境でテストしてください：

1. プラグインマネージャーに`nui.nvim`を**含めない**場合：
   - プラグイン初期化時に適切なエラーメッセージが表示されるか確認

2. プラグインマネージャーに`nui.nvim`を**含める**場合：
   - プラグインが正常に初期化されるか確認
   - 機能（サイドバー、バッファナビゲーション）が正常に動作するか確認

## 関連Issue

Fixes #25