### PR TITLE
feat: implement session management using SQLite

### DIFF
--- a/lua/pile/config.lua
+++ b/lua/pile/config.lua
@@ -3,6 +3,16 @@ local M = {
   debug = {
     enabled = false, -- デフォルトではデバッグログを無効化
     level = "info",  -- デバッグレベル: "error", "warn", "info", "debug", "trace"
+  },
+  -- セッション管理の設定
+  session = {
+    enabled = true,                -- セッション機能の有効/無効
+    auto_save = true,              -- 自動保存するか
+    auto_load = true,              -- 起動時に自動で最後のセッションを読み込むか
+    save_interval = 300,           -- 自動保存の間隔（秒）
+    db_path = nil,                 -- SQLiteのDBパス（nilの場合はデフォルト場所）
+    save_on_exit = true,           -- 終了時に自動保存するか
+    clear_buffers_on_load = false  -- セッション読み込み時に既存バッファをクリアするか
   }
 }
 
@@ -35,6 +45,18 @@ M.setup = function(opts)
   if opts and opts.debug ~= nil then
     M.debug.enabled = opts.debug.enabled ~= nil and opts.debug.enabled or M.debug.enabled
     M.debug.level = opts.debug.level ~= nil and opts.debug.level or M.debug.level
+  end
+
+  -- セッション設定
+  if opts and opts.session ~= nil then
+    -- 各設定項目をユーザー設定またはデフォルト値で設定
+    M.session.enabled = opts.session.enabled ~= nil and opts.session.enabled or M.session.enabled
+    M.session.auto_save = opts.session.auto_save ~= nil and opts.session.auto_save or M.session.auto_save
+    M.session.auto_load = opts.session.auto_load ~= nil and opts.session.auto_load or M.session.auto_load
+    M.session.save_interval = opts.session.save_interval ~= nil and opts.session.save_interval or M.session.save_interval
+    M.session.db_path = opts.session.db_path ~= nil and opts.session.db_path or M.session.db_path
+    M.session.save_on_exit = opts.session.save_on_exit ~= nil and opts.session.save_on_exit or M.session.save_on_exit
+    M.session.clear_buffers_on_load = opts.session.clear_buffers_on_load ~= nil and opts.session.clear_buffers_on_load or M.session.clear_buffers_on_load
   end
 
   -- バッファハイライト設定

--- a/lua/pile/init.lua
+++ b/lua/pile/init.lua
@@ -1,7 +1,8 @@
-Config = require("pile.config")
+local Config = require("pile.config")
 local buffers = require("pile.buffers")
 local sidebar = require("pile.windows.sidebar")
 local log = require("pile.log")
+local sqlite = require("pile.repositories.sqlite")
 
 local M = {}
 
@@ -17,6 +18,20 @@ local function check_dependencies()
     )
     return false
   end
+  
+  -- セッション機能が有効ならSQLiteの依存関係をチェック
+  if Config.session and Config.session.enabled then
+    local has_sqlite, _ = pcall(require, "sqlite")
+    if not has_sqlite then
+      log.warn("SQLite support is enabled, but sqlite.lua is not installed. Session functionality will be disabled.")
+      vim.notify(
+        "pile.nvim: Session functionality requires sqlite.lua, please install it to use sessions.",
+        vim.log.levels.WARN
+      )
+      Config.session.enabled = false
+    end
+  end
+  
   log.trace("All dependencies found")
   return true
 end
@@ -40,9 +55,49 @@ function M.setup(opts)
     fg = "White",
   })
 
+  -- 基本コマンドの登録
   vim.api.nvim_create_user_command("PileToggle", M.toggle_sidebar, { desc = "toggle pile window" })
   vim.api.nvim_create_user_command("PileGoToNextBuffer", M.switch_to_next_buffer, { desc = "go to next buffer" })
   vim.api.nvim_create_user_command("PileGoToPrevBuffer", M.switch_to_prev_buffer, { desc = "go to prev buffer" })
+  
+  -- セッション関連コマンドの登録
+  if Config.session.enabled then
+    vim.api.nvim_create_user_command("PileSaveSession", function(opts)
+      local name = opts.args ~= "" and opts.args or "default"
+      sqlite.save_session(name)
+    end, { nargs = "?", desc = "save current session" })
+    
+    vim.api.nvim_create_user_command("PileLoadSession", function(opts)
+      local name = opts.args ~= "" and opts.args or "default"
+      sqlite.load_session(name)
+    end, { nargs = "?", desc = "load a session" })
+    
+    vim.api.nvim_create_user_command("PileListSessions", function()
+      local sessions = sqlite.list_sessions()
+      if #sessions == 0 then
+        vim.notify("No saved sessions found", vim.log.levels.INFO)
+        return
+      end
+      
+      local lines = {"Saved Sessions:"}
+      for i, session in ipairs(sessions) do
+        table.insert(lines, string.format("%d. %s (updated: %s)", i, session.name, session.updated_at))
+      end
+      
+      vim.notify(table.concat(lines, "\n"), vim.log.levels.INFO)
+    end, { desc = "list all saved sessions" })
+    
+    vim.api.nvim_create_user_command("PileDeleteSession", function(opts)
+      if opts.args == "" then
+        vim.notify("Error: Session name required", vim.log.levels.ERROR)
+        return
+      end
+      sqlite.delete_session(opts.args)
+    end, { nargs = 1, desc = "delete a saved session" })
+    
+    -- セッション機能の初期化
+    sqlite.setup()
+  end
 end
 
 function M.toggle_sidebar()

--- a/lua/pile/repositories/sqlite.lua
+++ b/lua/pile/repositories/sqlite.lua
@@ -1,0 +1,354 @@
+local log = require("pile.log")
+local Config = require("pile.config")
+
+local M = {}
+
+-- SQLiteクライアントの初期化とテーブル作成
+local function initialize()
+  -- SQLite3の依存関係チェック
+  local has_sqlite, sqlite = pcall(require, "sqlite")
+  if not has_sqlite then
+    log.error("SQLite3 module not found. Please install sqlite.lua.")
+    vim.notify(
+      "pile.nvim requires sqlite.lua for session functionality. Please install it with your plugin manager.",
+      vim.log.levels.ERROR
+    )
+    return nil
+  end
+
+  -- データベースファイルのパスを設定
+  local db_path = Config.session.db_path or vim.fn.stdpath("data") .. "/pile_sessions.db"
+  log.debug("Using database path: " .. db_path)
+
+  -- データベース接続
+  local db = sqlite.new(db_path, {
+    busy_timeout = 1000, -- 1秒のタイムアウト
+  })
+
+  if not db then
+    log.error("Failed to initialize SQLite database")
+    return nil
+  end
+  
+  -- テーブルが存在しない場合は作成
+  db:exec([[
+    CREATE TABLE IF NOT EXISTS sessions (
+      id INTEGER PRIMARY KEY,
+      name TEXT UNIQUE,
+      created_at TIMESTAMP,
+      updated_at TIMESTAMP
+    );
+    
+    CREATE TABLE IF NOT EXISTS session_buffers (
+      id INTEGER PRIMARY KEY,
+      session_id INTEGER,
+      buffer_path TEXT,
+      display_order INTEGER,
+      cursor_position TEXT,
+      is_active BOOLEAN,
+      FOREIGN KEY(session_id) REFERENCES sessions(id) ON DELETE CASCADE
+    );
+  ]])
+  
+  log.debug("SQLite database initialized successfully")
+  return db
+end
+
+-- データベース接続の遅延初期化
+local function get_db()
+  if not M._db then
+    M._db = initialize()
+  end
+  return M._db
+end
+
+-- セッションの保存
+function M.save_session(name)
+  if not Config.session.enabled then
+    log.debug("Session functionality is disabled")
+    return false
+  end
+
+  local db = get_db()
+  if not db then
+    return false
+  end
+
+  local success = db:with_transaction(function()
+    -- 現在の時刻を取得
+    local timestamp = os.date("%Y-%m-%d %H:%M:%S")
+    
+    -- 既存のセッションを確認
+    local existing = db:select("sessions", { where = { name = name } })
+    local session_id
+    
+    if #existing > 0 then
+      -- 既存のセッションを更新
+      session_id = existing[1].id
+      db:update("sessions", {
+        updated_at = timestamp
+      }, {
+        id = session_id
+      })
+      
+      -- 既存のバッファ情報を削除
+      db:delete("session_buffers", {
+        session_id = session_id
+      })
+    else
+      -- 新しいセッションを作成
+      local result = db:insert("sessions", {
+        name = name,
+        created_at = timestamp,
+        updated_at = timestamp
+      })
+      session_id = result.lastInsertRowid
+    end
+    
+    -- バッファのリストを取得
+    local buffers = require("pile.buffers").get_list()
+    local current_buf = require("pile.buffers").get_current()
+    
+    -- 各バッファの情報を保存
+    for i, buffer in ipairs(buffers) do
+      -- カーソル位置を取得（現在のバッファのみ）
+      local cursor_position = ""
+      if buffer.buf == current_buf then
+        local cursor = vim.api.nvim_win_get_cursor(0)
+        cursor_position = string.format("%d,%d", cursor[1], cursor[2])
+      end
+      
+      -- バッファ情報をデータベースに保存
+      db:insert("session_buffers", {
+        session_id = session_id,
+        buffer_path = buffer.name,
+        display_order = i,
+        cursor_position = cursor_position,
+        is_active = (buffer.buf == current_buf)
+      })
+    end
+    
+    return true
+  end)
+  
+  if success then
+    log.info("Session '" .. name .. "' saved successfully")
+    return true
+  else
+    log.error("Failed to save session '" .. name .. "'")
+    return false
+  end
+end
+
+-- セッションの読み込み
+function M.load_session(name)
+  if not Config.session.enabled then
+    log.debug("Session functionality is disabled")
+    return false
+  end
+  
+  local db = get_db()
+  if not db then
+    return false
+  end
+  
+  -- セッションの存在を確認
+  local sessions = db:select("sessions", { where = { name = name } })
+  if #sessions == 0 then
+    log.warn("Session '" .. name .. "' not found")
+    return false
+  end
+  
+  local session_id = sessions[1].id
+  
+  -- バッファ情報を取得
+  local buffers = db:select("session_buffers", {
+    where = { session_id = session_id },
+    order_by = "display_order"
+  })
+  
+  if #buffers == 0 then
+    log.warn("No buffers found in session '" .. name .. "'")
+    return false
+  end
+  
+  -- 現在の全バッファをクリア（オプション設定による）
+  if Config.session.clear_buffers_on_load then
+    log.debug("Clearing existing buffers")
+    local current_buffers = vim.api.nvim_list_bufs()
+    for _, buf in ipairs(current_buffers) do
+      if vim.api.nvim_buf_is_valid(buf) and vim.api.nvim_buf_get_option(buf, 'modified') == false then
+        vim.api.nvim_buf_delete(buf, { force = false })
+      end
+    end
+  end
+  
+  -- バッファを読み込む
+  local active_buffer = nil
+  for _, buffer_info in ipairs(buffers) do
+    -- ファイルが存在する場合のみ読み込み
+    if vim.fn.filereadable(buffer_info.buffer_path) == 1 then
+      local buf = vim.cmd("edit " .. vim.fn.fnameescape(buffer_info.buffer_path))
+      
+      -- アクティブバッファを記録
+      if buffer_info.is_active then
+        active_buffer = {
+          buf = buf,
+          cursor = buffer_info.cursor_position
+        }
+      end
+    else
+      log.warn("File not found: " .. buffer_info.buffer_path)
+    end
+  end
+  
+  -- アクティブバッファにカーソルを設定
+  if active_buffer and active_buffer.cursor and active_buffer.cursor ~= "" then
+    local row, col = string.match(active_buffer.cursor, "(%d+),(%d+)")
+    if row and col then
+      vim.api.nvim_win_set_cursor(0, { tonumber(row), tonumber(col) })
+    end
+  end
+  
+  log.info("Session '" .. name .. "' loaded successfully")
+  return true
+end
+
+-- セッションの一覧を取得
+function M.list_sessions()
+  local db = get_db()
+  if not db then
+    return {}
+  end
+  
+  local sessions = db:select("sessions", { order_by = "updated_at DESC" })
+  return sessions
+end
+
+-- セッションの削除
+function M.delete_session(name)
+  local db = get_db()
+  if not db then
+    return false
+  end
+  
+  local success = db:with_transaction(function()
+    -- セッションの存在を確認
+    local sessions = db:select("sessions", { where = { name = name } })
+    if #sessions == 0 then
+      log.warn("Session '" .. name .. "' not found")
+      return false
+    end
+    
+    local session_id = sessions[1].id
+    
+    -- セッションバッファを削除
+    db:delete("session_buffers", { session_id = session_id })
+    
+    -- セッションを削除
+    db:delete("sessions", { id = session_id })
+    
+    return true
+  end)
+  
+  if success then
+    log.info("Session '" .. name .. "' deleted successfully")
+    return true
+  else
+    log.error("Failed to delete session '" .. name .. "'")
+    return false
+  end
+end
+
+-- 最後に更新されたセッションを自動的に読み込む
+function M.auto_load_last_session()
+  if not Config.session.enabled or not Config.session.auto_load then
+    log.debug("Auto-load session is disabled")
+    return false
+  end
+  
+  local db = get_db()
+  if not db then
+    return false
+  end
+  
+  local sessions = db:select("sessions", { 
+    order_by = "updated_at DESC",
+    limit = 1
+  })
+  
+  if #sessions == 0 then
+    log.debug("No sessions found for auto-load")
+    return false
+  end
+  
+  return M.load_session(sessions[1].name)
+end
+
+-- 自動保存機能
+function M.setup_auto_save()
+  if not Config.session.enabled or not Config.session.auto_save then
+    log.debug("Auto-save session is disabled")
+    return
+  end
+  
+  -- 自動保存用のタイマーを設定
+  local save_interval = Config.session.save_interval or 300 -- デフォルト5分
+  
+  -- タイマーが既に存在する場合はクリア
+  if M._auto_save_timer then
+    M._auto_save_timer:stop()
+    M._auto_save_timer = nil
+  end
+
+  -- 新しいタイマーを設定
+  M._auto_save_timer = vim.loop.new_timer()
+  M._auto_save_timer:start(
+    save_interval * 1000,  -- 最初の実行までの時間（ミリ秒）
+    save_interval * 1000,  -- 定期的な実行間隔（ミリ秒）
+    vim.schedule_wrap(function()
+      M.save_session("auto_save")
+    end)
+  )
+  
+  -- 終了時の自動保存設定
+  if Config.session.save_on_exit then
+    vim.api.nvim_create_autocmd("VimLeavePre", {
+      group = vim.api.nvim_create_augroup("PileSessionAutoSave", { clear = true }),
+      callback = function()
+        M.save_session("auto_save")
+      end,
+    })
+  end
+  
+  log.info("Auto-save session configured with interval: " .. save_interval .. "s")
+end
+
+-- 初期化関数
+function M.setup()
+  if not Config.session.enabled then
+    log.debug("Session functionality is disabled")
+    return
+  end
+  
+  -- データベース接続を初期化
+  local db = get_db()
+  if not db then
+    log.error("Failed to initialize SQLite database")
+    return
+  end
+  
+  -- 自動セッション機能の設定
+  M.setup_auto_save()
+  
+  -- 自動読み込み
+  if Config.session.auto_load then
+    vim.defer_fn(function()
+      M.auto_load_last_session()
+    end, 100) -- 少し遅延させて他の初期化が完了してから実行
+  end
+  
+  log.info("SQLite session manager initialized")
+end
+
+return M


### PR DESCRIPTION
## 概要
SQLiteを使用したセッション保存機能を実装しました（Issue #9対応）

## 変更内容
1. SQLiteを使用したバッファ状態の保存・復元機能
2. セッション管理のための設定オプション追加
3. セッション操作のユーザーコマンド追加

## 機能詳細
- バッファの状態をSQLiteデータベースに保存・復元
- セッションの手動保存/読み込み/削除
- 自動保存・自動読み込み機能
- 設定オプションで機能の有効/無効や挙動をカスタマイズ可能

## 追加したユーザーコマンド
- `PileSaveSession [名前]`: セッション保存（名前省略時は "default"）
- `PileLoadSession [名前]`: セッション読み込み（名前省略時は "default"）
- `PileListSessions`: セッション一覧表示
- `PileDeleteSession <名前>`: セッション削除

## 設定オプション
```lua
{
  session = {
    enabled = true,                -- セッション機能の有効/無効
    auto_save = true,              -- 自動保存するか
    auto_load = true,              -- 起動時に自動で最後のセッションを読み込むか
    save_interval = 300,           -- 自動保存の間隔（秒）
    db_path = nil,                 -- SQLiteのDBパス（nilの場合はデフォルト場所）
    save_on_exit = true,           -- 終了時に自動保存するか
    clear_buffers_on_load = false  -- セッション読み込み時に既存バッファをクリアするか
  }
}
```

## 依存関係
- SQLite機能を使用するには `sqlite.lua` パッケージが必要（自動検出し、なければ警告を表示）
- 依存パッケージがない場合は機能が自動的に無効化

Closes #9