### PR TITLE
feat: add configurable terminal buffer display option

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,44 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Overview
+pile.nvim is a Neovim plugin that provides a vertical buffer sidebar for managing open buffers, similar to how books are stacked in a pile. It's designed to offer an intuitive and simple buffer management experience.
+
+## Architecture
+The plugin follows a modular architecture:
+
+- **Core Module** (`lua/pile/init.lua`): Entry point that provides setup and command registration
+- **Config Module** (`lua/pile/config.lua`): Centralized configuration management with defaults
+- **Buffers Module** (`lua/pile/buffers/`): Buffer management, filtering, and duplicate file path handling
+- **Windows Module** (`lua/pile/windows/`): Window management including sidebar and popup components
+- **Logging Module** (`lua/pile/log.lua`): Debug logging system with configurable levels
+
+## Key Implementation Details
+
+### Buffer Filtering Logic
+The buffer list filters out:
+- Buffers without names
+- Popup, notify, and nofile buffer types
+- oil.nvim temporary buffers (oil:// protocol and oil filetype)
+- Only displays buffers that are either currently displayed in a window OR have file extensions
+
+### Duplicate File Handling
+When multiple files with the same name exist, the plugin intelligently displays minimal distinguishing path information by:
+1. Finding unique path segments among duplicates
+2. Preferring higher-level (closer to root) unique segments
+3. Falling back to parent directory display when no unique segments exist
+
+### Event-Driven Updates
+The sidebar automatically updates on:
+- BufAdd, BufLeave, BufEnter events
+- FileType changes (with special handling for oil.nvim integration)
+
+## Commands
+No build or test commands are currently defined for this plugin. The plugin is loaded directly by Neovim's plugin manager.
+
+## Development Guidelines
+- Use the debug logging system (`require('pile.log')`) for troubleshooting
+- Enable debug mode via setup options: `{ debug = { enabled = true, level = "debug" } }`
+- Maintain compatibility with oil.nvim for file browser integration
+- Required dependency: nui.nvim for UI components

--- a/lua/pile/buffers/init.lua
+++ b/lua/pile/buffers/init.lua
@@ -2,6 +2,7 @@ local globals = require('pile.globals')
 local window = require('pile.windows')
 local popup = require('pile.windows.popup')
 local log = require('pile.log')
+local config = require('pile.config')
 local M = {}
 
 local selected_buffer = nil
@@ -80,12 +81,14 @@ function M.get_list()
     -- 1. バッファに名前があること
     -- 2. ポップアップ、通知、特殊バッファでないこと
     -- 3. oil.nvimの一時バッファでないこと
-    -- 4. 表示されているか、特定の条件を満たすバッファであること
+    -- 4. ターミナルバッファのフィルタリング（設定による）
+    -- 5. 表示されているか、特定の条件を満たすバッファであること
     if info.filename ~= "" and 
        info.buftype ~= 'popup' and 
        info.filetype ~= 'notify' and 
        info.buftype ~= 'nofile' and
        not is_oil_temp_buffer(info.buf, info.name, info.filetype) and
+       (config.display.show_terminal_buffers or info.buftype ~= 'terminal') and
        (info.displayed or info.name:match("%.%w+$")) then -- 表示されているか、拡張子を持つファイル
       
       -- 同名ファイルの数をカウント

--- a/lua/pile/config.lua
+++ b/lua/pile/config.lua
@@ -3,6 +3,9 @@ local M = {
   debug = {
     enabled = false, -- デフォルトではデバッグログを無効化
     level = "info",  -- デバッグレベル: "error", "warn", "info", "debug", "trace"
+  },
+  display = {
+    show_terminal_buffers = false, -- ターミナルバッファを表示するかどうか
   }
 }
 
@@ -35,6 +38,11 @@ M.setup = function(opts)
   if opts and opts.debug ~= nil then
     M.debug.enabled = opts.debug.enabled ~= nil and opts.debug.enabled or M.debug.enabled
     M.debug.level = opts.debug.level ~= nil and opts.debug.level or M.debug.level
+  end
+
+  -- 表示設定
+  if opts and opts.display ~= nil then
+    M.display.show_terminal_buffers = opts.display.show_terminal_buffers ~= nil and opts.display.show_terminal_buffers or M.display.show_terminal_buffers
   end
 
   -- バッファハイライト設定


### PR DESCRIPTION
## Summary
- ターミナルバッファをサイドバーに表示するかどうかを設定可能にした
- デフォルトではターミナルバッファを非表示（従来通り）
- `display.show_terminal_buffers = true` で表示可能

## Changes
- `config.lua`: `display.show_terminal_buffers`設定オプションを追加（デフォルト：false）
- `buffers/init.lua`: 設定に基づいてターミナルバッファをフィルタリング
- コードにコメント追加でフィルタリング条件を明確化

## Usage
```lua
require('pile').setup({
  display = {
    show_terminal_buffers = true, -- ターミナルバッファを表示
  }
})
```

🤖 Generated with [Claude Code](https://claude.ai/code)