### PR TITLE
fix: make restored buffers navigable with bnext/bprev

### DIFF
--- a/lua/pile/buffers/init.lua
+++ b/lua/pile/buffers/init.lua
@@ -31,7 +31,6 @@ local function is_displayable_buffer(info)
     and info.filetype ~= 'notify'
     and info.buftype ~= 'nofile'
     and not is_oil_buffer(info.name, info.filetype)
-    and (info.displayed or info.name:match("%.%w+$"))
 end
 
 local function split_path_segments(path)


### PR DESCRIPTION
Previously, buffers restored from sessions were not navigable with
bnext/bprev unless they were already displayed in a window or had
a file extension. This was due to an overly restrictive check in
is_displayable_buffer().

The check `(info.displayed or info.name:match("%.%w+$"))` required
buffers to either be displayed in a window or have a file extension.
Since restored buffers are loaded but not immediately displayed,
they were filtered out from the navigable buffer list.

Fix: Remove the restrictive display/extension check. The existing
`info.filename ~= ""` check is sufficient to ensure valid buffers.
This allows all loaded buffers with valid filenames to be navigable,
regardless of their display status.

Fixes the issue where session-restored buffers cannot be navigated
immediately after restoration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved buffer display filtering to show more buffers in the buffer list, including those without file extensions and buffers not currently displayed.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->